### PR TITLE
Generate name

### DIFF
--- a/boxliner/container.py
+++ b/boxliner/container.py
@@ -24,6 +24,7 @@ import os
 
 import docker
 import halo
+import namesgenerator
 
 from boxliner import util
 
@@ -42,14 +43,11 @@ class Container(object):
         self._d = d
         self._client = docker.from_env()
         self._goss_cmd = '/goss validate --color --format documentation'
-
-    @property
-    def name(self):
-        return self._d['name']
+        self._name = namesgenerator.get_random_name()
 
     @property
     def container_name(self):
-        return '{}@{}'.format(self.name, self.image)
+        return '{}@{}'.format(self._name, self.image)
 
     @property
     def image(self):
@@ -109,8 +107,8 @@ class Container(object):
             'image': self.image,
             'detach': True,
             'remove': False,
-            'name': self.name,
-            'hostname': self.name,
+            'name': self._name,
+            'hostname': self._name,
         }
 
         msg = 'Running container:{}'.format(self.container_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ click-completion==0.5.0
 colorama==0.4.1
 docker==3.7.0
 halo==0.0.23
+namesgenerator==0.3
 pbr==5.1.2
 PyYAML==4.2b1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -29,8 +29,7 @@ from boxliner import config
 def config_data():
     return """
 containers:
-  - name: instance
-    image: solita/ubuntu-systemd:latest
+  - image: solita/ubuntu-systemd:latest
     command: /sbin/init
     goss_file: ./test/test.yml
     goss_binary: /Users/jodewey/Downloads/goss-linux-amd64

--- a/test/example.yml
+++ b/test/example.yml
@@ -1,7 +1,6 @@
 ---
 containers:
-  - name: instance
-    image: solita/ubuntu-systemd:latest
+  - image: solita/ubuntu-systemd:latest
     command: /sbin/init
     goss_file: ./test/test.yml
     goss_binary: /Users/jodewey/Downloads/goss-linux-amd64

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -26,8 +26,6 @@ from boxliner import container
 def test_config_member(config_instance):
     x = {
         'containers': [{
-            'name':
-            'instance',
             'image':
             'solita/ubuntu-systemd:latest',
             'command':

--- a/test/test_container.py
+++ b/test/test_container.py
@@ -34,31 +34,25 @@ def _instance(config_instance):
     return container.Container(c)
 
 
-def test_name_member(_instance):
-    x = 'instance'
-
-    assert x == _instance.name
-
-
-def test_image_member(_instance):
+def test_image_property(_instance):
     x = 'solita/ubuntu-systemd:latest'
 
     assert x == _instance.image
 
 
-def test_command_member(_instance):
+def test_command_property(_instance):
     x = '/sbin/init'
 
     assert x == _instance.command
 
 
-def test_goss_file_member(_instance):
+def test_goss_file_property(_instance):
     x = os.path.abspath('test/test.yml')
 
     assert x == _instance.goss_file
 
 
-def test_goss_binary_member(_instance):
+def test_goss_binary_property(_instance):
     x = '/Users/jodewey/Downloads/goss-linux-amd64'
 
     assert x == _instance.goss_binary


### PR DESCRIPTION
Generate name passed to docker vs relying on docker created or
user supplied name.  Allows us to reference name of container
in output w/o having to create the container first.